### PR TITLE
fix: separate alt-screen config from runtime state

### DIFF
--- a/src/charm/program.clj
+++ b/src/charm/program.clj
@@ -205,8 +205,6 @@
     (try
       ;; Setup renderer
       (render/start! renderer)
-      (when alt-screen
-        (render/enter-alt-screen! renderer))
 
       ;; Setup mouse
       (when mouse

--- a/src/charm/render/core.clj
+++ b/src/charm/render/core.clj
@@ -28,6 +28,7 @@
            :display display
            :fps fps
            :alt-screen alt-screen
+           :in-alt-screen false
            :hide-cursor hide-cursor
            :width width
            :height height
@@ -71,19 +72,19 @@
 (defn enter-alt-screen!
   "Enter the alternate screen buffer."
   [renderer]
-  (when-not (:alt-screen @renderer)
+  (when-not (:in-alt-screen @renderer)
     (let [terminal (:terminal @renderer)]
       (term/enter-alt-screen terminal)
+      (swap! renderer assoc :in-alt-screen true)
       (term/clear-screen terminal)
-      (term/cursor-home terminal))
-    (swap! renderer assoc :alt-screen true)))
+      (term/cursor-home terminal))))
 
 (defn exit-alt-screen!
   "Exit the alternate screen buffer."
   [renderer]
-  (when (:alt-screen @renderer)
+  (when (:in-alt-screen @renderer)
     (term/exit-alt-screen (:terminal @renderer))
-    (swap! renderer assoc :alt-screen false)))
+    (swap! renderer assoc :in-alt-screen false)))
 
 (defn clear-screen!
   "Clear the screen."
@@ -236,8 +237,8 @@
 (defn stop!
   "Stop the renderer and restore terminal state."
   [renderer]
-  (let [{:keys [alt-screen hide-cursor]} @renderer]
-    (when alt-screen
+  (let [{:keys [in-alt-screen hide-cursor]} @renderer]
+    (when in-alt-screen
       (exit-alt-screen! renderer))
     (when hide-cursor
       (show-cursor! renderer))

--- a/test/charm/render/core_test.clj
+++ b/test/charm/render/core_test.clj
@@ -14,6 +14,7 @@
         (is (some? @renderer))
         (is (= 60 (:fps @renderer)))
         (is (false? (:alt-screen @renderer)))
+        (is (false? (:in-alt-screen @renderer)))
         (is (true? (:hide-cursor @renderer)))
         (is (nat-int? (:width @renderer)))
         (is (nat-int? (:height @renderer)))
@@ -26,6 +27,7 @@
       (try
         (is (= 30 (:fps @renderer)))
         (is (true? (:alt-screen @renderer)))
+        (is (false? (:in-alt-screen @renderer)))
         (finally
           (term/close terminal))))))
 
@@ -49,3 +51,35 @@
           (is (nat-int? h)))
         (finally
           (term/close terminal))))))
+
+(deftest alt-screen-lifecycle-test
+  (testing "start!/stop! use configured alt-screen and track active state separately"
+    (let [calls (atom [])
+          renderer (atom {:terminal :fake
+                          :alt-screen true
+                          :in-alt-screen false
+                          :hide-cursor false
+                          :running false})]
+      (with-redefs [term/enter-alt-screen (fn [_] (swap! calls conj :enter))
+                    term/clear-screen (fn [_] (swap! calls conj :clear))
+                    term/cursor-home (fn [_] (swap! calls conj :home))
+                    term/exit-alt-screen (fn [_] (swap! calls conj :exit))
+                    r/disable-mouse! (fn [_] (swap! calls conj :disable-mouse))
+                    r/disable-focus-reporting! (fn [_] (swap! calls conj :disable-focus))
+                    r/show-cursor! (fn [_] (swap! calls conj :show-cursor))]
+        ;; Stop before start should not send exit alt-screen.
+        (r/stop! renderer)
+        (is (= [:disable-mouse :disable-focus] @calls))
+        (reset! calls [])
+
+        (r/start! renderer)
+        (is (= [:enter :clear :home] @calls))
+        (is (true? (:in-alt-screen @renderer)))
+
+        ;; Enter should be idempotent once active.
+        (r/start! renderer)
+        (is (= [:enter :clear :home] @calls))
+
+        (r/stop! renderer)
+        (is (= [:enter :clear :home :exit :disable-mouse :disable-focus] @calls))
+        (is (false? (:in-alt-screen @renderer)))))))


### PR DESCRIPTION
## What this fixes

  `alt-screen` mode wasn’t reliably entering fullscreen.

  ## Why it happened

  The renderer used `:alt-screen` both as:
  - the option from config, and
  - the current runtime state.

  So when `:alt-screen` was true, the enter logic could think it was already in alt-screen and skip it.

  ## What changed

  - Keep `:alt-screen` as the config option.
  - Add `:in-alt-screen` for runtime tracking.
  - Remove a duplicate alt-screen enter call in `program/run`.
  - Add a test that covers start/stop/idempotent alt-screen behavior.

  ## Result

  Fullscreen/alt-screen now enters and exits correctly.

  ## Check

  Ran `clojure -M:test` and all tests pass.