### PR TITLE
Feat: Table accepts vector of maps as input (tabular maps)

### DIFF
--- a/src/charm/components/table.clj
+++ b/src/charm/components/table.clj
@@ -53,11 +53,11 @@
         tbl-rows (mapv #(vec (vals %)) tbl-map)]
     [tbl-headers tbl-rows]))
 
-;; TEST: Write tests for this function
 (defn- columnsv->charm-headers
   "Convert vector of strings that represent headers, to a headers format
   consumable by charm.clj tables."
   [headersv & {:keys [header-opts]}]
+  {:pre [(and (sequential? headersv) (not (empty? headersv)))]}
   (let [header-default-width 20
         header-opts-str (stringify-keys header-opts)]
     (map (fn [header]
@@ -143,14 +143,6 @@
     :row-style row-style
     :cursor-style (or cursor-style (style/style :fg :cyan :bold true))
     :keys (merge default-keys keys)}))
-
-(comment
-  ;; TODO: these can be good basis for testing different arities of `table`
-  (table [{:foo "x" :bar "y"} {:foo "z" :bar "t"}])
-  (table [{:foo "x" :bar "y"} {:foo "z" :bar "t"}] {:header-opts {:foo {:title "FOOW" :width 40}}
-                                                    :cursor 3
-                                                    :keys {:cursor-up ["h"]}})
-  (table [{:title "foo"} {:title "bar"}] [["x" "y"] ["a" "b"]]))
 
 ;; ---------------------------------------------------------------------------
 ;; Table Accessors

--- a/src/charm/components/table.clj
+++ b/src/charm/components/table.clj
@@ -107,12 +107,24 @@
      :keys         - Custom key bindings
      :id           - Unique ID"
   ([table-map]
-   (table table-map nil))
-  ([table-map {:keys [header-opts] :as opts}]
    (let [[columnsv rowsv] (table-map->cols+rows table-map)
-         charm-headers (columnsv->charm-headers columnsv
-                                                :header-opts header-opts)]
-     (table charm-headers rowsv opts)))
+         charm-headers (columnsv->charm-headers columnsv :header-opts nil)]
+     (table charm-headers rowsv)))
+  ([table-map {:keys [header-opts] :as opts}]
+   (cond
+     (map? opts)
+     (let [[columnsv rowsv] (table-map->cols+rows table-map)
+           charm-headers (columnsv->charm-headers columnsv
+                                                  :header-opts header-opts)]
+       (table charm-headers rowsv opts))
+
+     (vector? opts)
+     (table table-map opts nil)
+
+     :else
+     (throw (IllegalArgumentException.
+             (str "Expected second argument to be a map (tabular map options) "
+                  "or a vector (explicit row data), got: " (pr-str opts))))))
   ([columns rows & {:keys [cursor height header?
                            header-style row-style cursor-style
                            keys id]

--- a/src/charm/components/table.clj
+++ b/src/charm/components/table.clj
@@ -61,15 +61,10 @@
   (let [header-default-width 20
         header-opts-str (stringify-keys header-opts)]
     (map (fn [header]
-           (let [col-opts (get header-opts-str header)]
-             (if (nil? col-opts)
-               {:title header :width header-default-width}
-               {:title (if (col-opts "title")
-                         (col-opts "title")
-                         header)
-                :width (if (col-opts "width")
-                         (col-opts "width")
-                         header-default-width)})))
+           (if-let [col-opts (get header-opts-str header)]
+             {:title (or (col-opts "title") header)
+              :width (or (col-opts "width") header-default-width)}
+             {:title header :width header-default-width}))
          headersv)))
 
 (defn table
@@ -88,7 +83,7 @@
      [{:name \"John\" :family-name \"Doe\"}
       {:name \"Jane\" :family-name \"Dough\"}]
      ```
-     It is also recommended to pass `header-opts` with this type of invocation
+     It also optionally accepts `header-opts` along with other table options
      otherwise, defaults will be used.
      - `header-opts` is a map for specifying options like width and title of columns.
        ```
@@ -109,7 +104,7 @@
   ([table-map]
    (let [[columnsv rowsv] (table-map->cols+rows table-map)
          charm-headers (columnsv->charm-headers columnsv :header-opts nil)]
-     (table charm-headers rowsv)))
+     (table charm-headers rowsv nil)))
   ([table-map {:keys [header-opts] :as opts}]
    (cond
      (map? opts)

--- a/src/charm/components/table.clj
+++ b/src/charm/components/table.clj
@@ -75,39 +75,70 @@
 (defn table
   "Create a table component.
 
-   Columns is a vector of column definitions:
-     [{:title \"Name\" :width 20} {:title \"Value\" :width 30}]
+  Two formats of input data is supported:
+  1. Explicit columns and rows:
+     Columns is a vector of column definitions:
+     `[{:title \"Name\" :width 20} {:title \"Value\" :width 30}]`
 
-   Rows is a vector of row vectors (each row has one value per column):
-     [[\"foo\" \"bar\"] [\"baz\" \"qux\"]]
+     Rows is a vector of row vectors (each row has one value per column):
+     `[[\"foo\" \"bar\"] [\"baz\" \"qux\"]]`
+  2. Tabular map data. Key names will automatically become column titles, and their
+     values will be row data.
+     ```
+     [{:name \"John\" :family-name \"Doe\"}
+      {:name \"Jane\" :family-name \"Dough\"}]
+     ```
+     It is also recommended to pass `header-opts` with this type of invocation
+     otherwise, defaults will be used.
+     - `header-opts` is a map for specifying options like width and title of columns.
+       ```
+       {:name {:title \"Name\" :width 20}
+        :family-name {:title \"Family Name\" :width 35}}
+       ```
 
    Options:
      :cursor       - Row cursor position (nil = not interactive, int = selected row)
      :height       - Visible height in rows (0 = show all rows)
      :header?      - Show header row (default true)
      :header-style - Style for header text
+     :header-opts? - Header options (for using with tabular map)
      :row-style    - Style for normal row text
      :cursor-style - Style for selected row text
      :keys         - Custom key bindings
      :id           - Unique ID"
-  [columns rows & {:keys [cursor height header?
-                          header-style row-style cursor-style
-                          keys id]
-                   :or {height 0
-                        header? true
-                        id (rand-int 1000000)}}]
-  {:type :table
-   :id id
-   :columns (vec columns)
-   :rows (vec rows)
-   :cursor cursor
-   :offset 0
-   :height height
-   :header? header?
-   :header-style (or header-style (style/style :bold true))
-   :row-style row-style
-   :cursor-style (or cursor-style (style/style :fg :cyan :bold true))
-   :keys (merge default-keys keys)})
+  ([table-map]
+   (table table-map nil))
+  ([table-map {:keys [header-opts] :as opts}]
+   (let [[columnsv rowsv] (table-map->cols+rows table-map)
+         charm-headers (columnsv->charm-headers columnsv
+                                                :header-opts header-opts)]
+     (table charm-headers rowsv opts)))
+  ([columns rows & {:keys [cursor height header?
+                           header-style row-style cursor-style
+                           keys id]
+                    :or {height 0
+                         header? true
+                         id (rand-int 1000000)}}]
+   {:type :table
+    :id id
+    :columns (vec columns)
+    :rows (vec rows)
+    :cursor cursor
+    :offset 0
+    :height height
+    :header? header?
+    :header-style (or header-style (style/style :bold true))
+    :row-style row-style
+    :cursor-style (or cursor-style (style/style :fg :cyan :bold true))
+    :keys (merge default-keys keys)}))
+
+(comment
+  ;; TODO: these can be good basis for testing different arities of `table`
+  (table [{:foo "x" :bar "y"} {:foo "z" :bar "t"}])
+  (table [{:foo "x" :bar "y"} {:foo "z" :bar "t"}] {:header-opts {:foo {:title "FOOW" :width 40}}
+                                                    :cursor 3
+                                                    :keys {:cursor-up ["h"]}})
+  (table [{:title "foo"} {:title "bar"}] [["x" "y"] ["a" "b"]]))
 
 ;; ---------------------------------------------------------------------------
 ;; Table Accessors

--- a/src/charm/components/table.clj
+++ b/src/charm/components/table.clj
@@ -15,7 +15,8 @@
    [charm.ansi.width :as w]
    [charm.message :as msg]
    [charm.style.core :as style]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [clojure.walk :refer [stringify-keys]]))
 
 ;; ---------------------------------------------------------------------------
 ;; Key Bindings
@@ -38,6 +39,38 @@
 ;; ---------------------------------------------------------------------------
 ;; Table Creation
 ;; ---------------------------------------------------------------------------
+
+(defn table-map->cols+rows
+  "Convert a tabular map format to separate columns vector and rows vector (vec of vecs).
+
+  * Args
+    * tbl-map: a tabular map structure.
+        ` [{:name \"John\" :family-name \"Doe\"} {:name \"Jane\" :family-name \"Dough\"}]`
+  * Returns
+    `[tbl-headers tbl-rows]`"
+  [tbl-map]
+  (let [tbl-headers (vec (keys (stringify-keys (first tbl-map))))
+        tbl-rows (mapv #(vec (vals %)) tbl-map)]
+    [tbl-headers tbl-rows]))
+
+;; TEST: Write tests for this function
+(defn- columnsv->charm-headers
+  "Convert vector of strings that represent headers, to a headers format
+  consumable by charm.clj tables."
+  [headersv & {:keys [header-opts]}]
+  (let [header-default-width 20
+        header-opts-str (stringify-keys header-opts)]
+    (map (fn [header]
+           (let [col-opts (get header-opts-str header)]
+             (if (nil? col-opts)
+               {:title header :width header-default-width}
+               {:title (if (col-opts "title")
+                         (col-opts "title")
+                         header)
+                :width (if (col-opts "width")
+                         (col-opts "width")
+                         header-default-width)})))
+         headersv)))
 
 (defn table
   "Create a table component.

--- a/test/charm/components/table_test.clj
+++ b/test/charm/components/table_test.clj
@@ -20,11 +20,32 @@
    {:name "Jane" :family-name "Douglass"}])
 
 (deftest table-creation-test
+  ;; TODO: test if wrong argumnets are handled
   (testing "create table"
     (let [tbl (table/table sample-columns sample-rows)]
       (is (= :table (:type tbl)))
       (is (= sample-rows (table/table-rows tbl)))
       (is (nil? (table/table-cursor tbl)))))
+
+  (testing "create table with vector of maps"
+    (testing "basic tabular map"
+      (let [tbl (table/table sample-tabular-map)]
+        (is (= :table (:type tbl)))
+        (is (= [["John" "Doe"] ["Jane" "Douglass"]]
+               (table/table-rows tbl)))))
+
+    (testing "with header-opts"
+      (let [tbl (table/table sample-tabular-map
+                             {:header-opts {:name {:title "Name" :width 30}}})]
+        (is (= "Name" (:title (first (:columns tbl)))))
+        (is (= 30 (:width (first (:columns tbl)))))
+        (is (= 20 (:width (second (:columns tbl)))))))
+
+    (testing "with nested opts like :keys"
+      (let [tbl (table/table sample-tabular-map
+                             {:keys {:cursor-up ["h"]} :cursor 0})]
+        (is (= ["h"] (get-in tbl [:keys :cursor-up])))
+        (is (= 0 (table/table-cursor tbl))))))
 
   (testing "create table with cursor"
     (let [tbl (table/table sample-columns sample-rows :cursor 0)]
@@ -180,3 +201,26 @@
       (is (and
            (= (val (ffirst sample-tabular-map)) (ffirst rowsv))
            (= (val (last (last sample-tabular-map))) (last (last rowsv))))))))
+
+(deftest columnsv->charm-headers-test
+  (testing "Correct inputs return correct results"
+    (testing "without header-opts"
+      (let [result (#'table/columnsv->charm-headers ["foo" "bar"])]
+        (is (= '({:title "foo" :width 20} {:title "bar" :width 20})
+               result))))
+    (testing "with header-opts"
+      (let [result (#'table/columnsv->charm-headers
+                     ["foo" "bar"]
+                     {:header-opts {:foo {:title "FOO" :width 40}}})]
+        (is (= '({:title "FOO" :width 40} {:title "bar" :width 20})
+               result)))))
+  (testing "Bad inputs are handled"
+    (testing "string instead of vector"
+      (is (thrown? AssertionError
+                   (#'table/columnsv->charm-headers "foo"))))
+    (testing "empty headers"
+      (is (thrown? AssertionError
+                   (#'table/columnsv->charm-headers []))))
+    (testing "nil headers"
+      (is (thrown? AssertionError
+                   (#'table/columnsv->charm-headers nil))))))

--- a/test/charm/components/table_test.clj
+++ b/test/charm/components/table_test.clj
@@ -3,6 +3,8 @@
    [charm.components.table :as table]
    [charm.message :as msg]
    [clojure.string :as str]
+   [clojure.walk :refer [stringify-keys]]
+   [clojure.set :refer [difference]]
    [clojure.test :refer [deftest is testing]]))
 
 (def sample-columns
@@ -12,6 +14,10 @@
   [["foo" "bar"]
    ["baz" "qux"]
    ["hello" "world"]])
+
+(def sample-tabular-map
+  [{:name "John" :family-name "Doe"}
+   {:name "Jane" :family-name "Douglass"}])
 
 (deftest table-creation-test
   (testing "create table"
@@ -162,3 +168,15 @@
           [new-tbl cmd] (table/table-init tbl)]
       (is (= tbl new-tbl))
       (is (nil? cmd)))))
+
+(deftest table-map->cols+rows-test
+  (testing "returns correct output for correct input"
+    (let [[columnsv rowsv] (table/table-map->cols+rows sample-tabular-map)]
+      ;; Columns are correctly parsed
+      (is (empty? (difference
+                   (set columnsv)
+                   (set (keys (stringify-keys (first sample-tabular-map)))))))
+      ;; Rows are correctly parsed
+      (is (and
+           (= (val (ffirst sample-tabular-map)) (ffirst rowsv))
+           (= (val (last (last sample-tabular-map))) (last (last rowsv))))))))


### PR DESCRIPTION
This feature enables users to pass a vector of maps to `table` and the table will automatically create rows and columns

```clojure
(table/table [{:name "John" :family-name "Doe"}
                       {:name "Jane" :family-name "Dough"}])
```
This will render a table:

| name | family-name |
|----------|--------------------|
| John   | Doe                 |
| Jane   | Dough            |

It can optionally take a `:header-opts` along with other table options:

```clojure
(table/table [{:name "John" :family-name "Doe"}
                       {:name "Jane" :family-name "Dough"}]
                      {:header-opts {:name {:title "NAME" :width 40}}
                       :cursor 2})
```

| NAME | family-name |
|----------|--------------------|
| John   | Doe                 |
| Jane   | Dough            |

- Wrote tests for all the new functions and functionality
- Optimized and refactored to sensible degree


** This PR introduces no breaking changes**