### PR TITLE
fix: bind shift+tab (CSI Z backtab) escape sequence

### DIFF
--- a/src/charm/input/keymap.clj
+++ b/src/charm/input/keymap.clj
@@ -73,7 +73,8 @@
 
 (def ^:private special-keys
   "Special key sequences (focus, paste)."
-  [{:event {:type :focus}       :seqs ["[I"]}
+  [{:event {:type :tab :shift true} :seqs ["[Z"]}
+   {:event {:type :focus}       :seqs ["[I"]}
    {:event {:type :blur}        :seqs ["[O"]}
    {:event {:type :paste-start} :seqs ["[200~"]}
    {:event {:type :paste-end}   :seqs ["[201~"]}])

--- a/test/charm/input/keys_test.clj
+++ b/test/charm/input/keys_test.clj
@@ -58,6 +58,9 @@
     (is (= {:type :focus} (k/parse-escape-sequence "[I")))
     (is (= {:type :blur} (k/parse-escape-sequence "[O"))))
 
+  (testing "shift+tab (backtab)"
+    (is (= {:type :tab :shift true} (k/parse-escape-sequence "[Z"))))
+
   (testing "unknown sequences"
     (let [result (k/parse-escape-sequence "[999X")]
       (is (= :unknown (:type result)))

--- a/test/charm/integration/input_test.clj
+++ b/test/charm/integration/input_test.clj
@@ -80,6 +80,11 @@
       (is (= {:type :tab}
              (input/read-event terminal)))))
 
+  (testing "shift+tab (backtab)"
+    (with-test-terminal [terminal "\u001b[Z"]
+      (is (= {:type :tab :shift true}
+             (input/read-event terminal)))))
+
   (testing "backspace (DEL)"
     (with-test-terminal [terminal "\u007f"]
       (is (= {:type :backspace}


### PR DESCRIPTION
## What

Terminals send `ESC [ Z` for shift+tab (backtab), but the keymap had no binding for it, so backtab presses arrived as unknown events and could not be matched with `(msg/key-match? msg "shift+tab")`. This binds `[Z` to `{:type :tab :shift true}` alongside the other special keys.

## Why

Found while building a form wizard on charm.clj: Tab moved focus forward but shift+tab could not move it backward, since the event never reached the update function as a key press.

## Testing

- Unit test in `keys_test.clj` (`parse-escape-sequence` on `[Z`), following the focus-events pattern
- Integration test in `integration/input_test.clj` (`read-event` on `\u001b[Z` via the dumb-terminal harness), following the plain-tab pattern
- `bb test` (JVM) and `bb test:bb`: 152 tests, 940 assertions, 0 failures; `bb format` and `bb lint` clean
- Verified interactively in a real TUI: shift+tab now matches `"shift+tab"` in `key-match?` and cycles focus backward

🤖 Generated with [Claude Code](https://claude.com/claude-code)